### PR TITLE
メッセージ送信の非同期化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'coffee-rails', '~> 4.2'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,9 +221,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -264,7 +261,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,66 @@
+$(function(){
+  function buildHTML(message){
+    if ( message.image ) {
+      var html =
+       `<div class="message">
+          <div class="message__info">
+            <p class="message__info__username">
+              ${message.user_name}
+            </p>
+            <p class="message__info__date">
+              ${message.created_at}
+            </p>
+          </div>
+          <p class="message__text"></p>
+          <p class="message__text__content">
+            ${message.content}
+          </p>
+          <img src=${message.image} >
+        </div>`
+      return html;
+    } else {
+      var html =
+        `<div class="message">
+          <div class="message__info">
+            <p class="message__info__username">
+              ${message.user_name}
+            </p>
+            <p class="message__info__date">
+              ${message.created_at}
+            </p>
+          </div>
+          <p class="message__text"></p>
+          <p class="message__text__content">
+            ${message.content}
+          </p>
+          <p></p>
+        </div>`
+      return html;
+    };
+  }
+
+  $('#new_message').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.messages').append(html);
+      $('form')[0].reset();
+      $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+      $('.submit-btn').prop('disabled', false);
+    })
+    .fail(function(){
+      alert("メッセージ送信に失敗しました");
+    });
+  });
+
+});

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,12 +9,15 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'
       render :index
     end
+
   end
 
   private

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,8 @@
     %meta{content: "text/html; charset=UTF-8", "http-equiv": "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -9,4 +9,3 @@
       %p.message__text__content
         = message.content
     = image_tag message.image.url, class: 'message__text__image' if message.image.present?
-    

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.content @message.content
+json.image @message.image_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,8 @@ Bundler.require(*Rails.groups)
 
 module ChatSpace
   class Application < Rails::Application
+    config.time_zone = 'Tokyo'
+    
     config.generators do |g|
       g.stylesheets false
       g.javascripts false


### PR DESCRIPTION
# What
ChatSpaceに非同期通信を実装するにあたり、以下の作業内容を実施した。
　1.jQuery使用に当たり、turbolinksを停止させ、jsファイルを作成。
　2.フォームが送信されたら、イベントが発火するように設定し、イベントが発火したときに
　　Ajaxを使用して、messages#createが動くようにする。
　3.「messages_controller」のcreateメソッドでメッセージを保存し、respond_toを使用して
　　HTMLとJSONの場合で処理をわける。
　4.jbuilderを使用して、作成したメッセージをJSON形式で返すよう設定。
　5.返ってきたJSONをdoneメソッドで受取り、HTMLを作成。
　6.非同期に失敗した場合の処理も設定。

以下、gifの動画キャプチャ
テキストのみ投稿／SENDボタンを連打　https://gyazo.com/2e8c87eb48ad41a59dfa5679c3317cfe
テキストと画像を投稿　https://gyazo.com/1a407c4b0073158eb17d339ec281192f
画像のみ投稿　https://gyazo.com/12c9e87df2d58b2e25e73843f616ca1f

# Why
これまでの実装だと、メッセージを送信するたびにブラウザがリロードされてしまうため、
画面をリロードしなくても情報が反映される非同期化を行った。