### PR TITLE
メッセージ自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,8 +1,9 @@
 $(function(){
+
   function buildHTML(message){
     if ( message.image ) {
       var html =
-       `<div class="message">
+       `<div class="message" data-message-id=${message.id}>
           <div class="message__info">
             <p class="message__info__username">
               ${message.user_name}
@@ -20,7 +21,7 @@ $(function(){
       return html;
     } else {
       var html =
-        `<div class="message">
+        `<div class="message" data-message-id=${message.id}>
           <div class="message__info">
             <p class="message__info__username">
               ${message.user_name}
@@ -63,4 +64,29 @@ $(function(){
     });
   });
 
+  var reloadMessages = function() {
+    var last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.messages').append(insertHTML);
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+      }
+     })
+    .fail(function() {
+      alert('error');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .message__info
     %p.message__info__username
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
 json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
-json.image @message.image_url
+json.image @message.image.url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
メッセージ画面が自動で更新されるように、以下の実装を行った。
1.jQueryを使って表示されている最新メッセージのidを取得できるように、
メッセージのidをカスタムデータ属性として追加した。
2.新規投稿を取得できるようにするため、コントローラーに新規投稿を確認するアクションを、
WebAPIを用いて追加し、このアクションを呼び出すルーティングを追加した。
3.投稿内容をレスポンスできるように、json形式でレスポンスするためのファイルを作成し、
jBuilderの設定を行った。
4.message.jsを編集し、取得した最新のメッセージをブラウザのメッセージ一覧に
追加できるようにし、数秒ごとにリクエストするよう設定をした。
5.メッセージを取得したら画面がスクロールしたり、自動更新が必要ない画面では
行わないようにするために、message.jsを編集した。
画像を送信　https://gyazo.com/250a7310c1951329287c919815d07853
文章を送信　https://gyazo.com/a9783c676991b5819be20737dcb2b1c2
自動更新が他のグループに影響しないかの確認　https://gyazo.com/ec14df33ebc63fe39b601b742afcafe5

# Why
メッセージに自動更新機能を実装することで、自分以外のユーザーからのメッセージが自動でチャット画面に反映され、都度リロードすることなく相手からのメッセージが表示されるため、実用的なチャットアプリに近づけることができる。